### PR TITLE
Add localization support for 59 languages

### DIFF
--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Адрас SOCKS:</string>
+    <string name="socks_udp_addr">UDP-адрас SOCKS:</string>
+    <string name="socks_port">Порт SOCKS:</string>
+    <string name="socks_user">Імя карыстальніка SOCKS:</string>
+    <string name="socks_pass">Пароль SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP праз TCP</string>
+    <string name="remote_dns">Аддалены DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Глабальна</string>
+    <string name="apps">Праграмы</string>
+    <string name="save">Захаваць</string>
+    <string name="control_enable">Уключыць</string>
+    <string name="control_disable">Выключыць</string>
+</resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Adreça SOCKS:</string>
+    <string name="socks_udp_addr">Adreça UDP SOCKS:</string>
+    <string name="socks_port">Port SOCKS:</string>
+    <string name="socks_user">Usuari SOCKS:</string>
+    <string name="socks_pass">Contrasenya SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP sobre TCP</string>
+    <string name="remote_dns">DNS remot</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Aplicacions</string>
+    <string name="save">Desa</string>
+    <string name="control_enable">Activa</string>
+    <string name="control_disable">Desactiva</string>
+</resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Adresa SOCKS:</string>
+    <string name="socks_udp_addr">UDP adresa SOCKS:</string>
+    <string name="socks_port">Port SOCKS:</string>
+    <string name="socks_user">Uživatelské jméno SOCKS:</string>
+    <string name="socks_pass">Heslo SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP přes TCP</string>
+    <string name="remote_dns">Vzdálený DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globální</string>
+    <string name="apps">Aplikace</string>
+    <string name="save">Uložit</string>
+    <string name="control_enable">Zapnout</string>
+    <string name="control_disable">Vypnout</string>
+</resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-adresse:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-adresse:</string>
+    <string name="socks_port">SOCKS-port:</string>
+    <string name="socks_user">SOCKS-brugernavn:</string>
+    <string name="socks_pass">SOCKS-adgangskode:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP over TCP</string>
+    <string name="remote_dns">Fjern-DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Apps</string>
+    <string name="save">Gem</string>
+    <string name="control_enable">Aktivér</string>
+    <string name="control_disable">Deaktivér</string>
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-Adresse:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-Adresse:</string>
+    <string name="socks_port">SOCKS-Port:</string>
+    <string name="socks_user">SOCKS-Benutzername:</string>
+    <string name="socks_pass">SOCKS-Passwort:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP über TCP</string>
+    <string name="remote_dns">Entfernter DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Apps</string>
+    <string name="save">Speichern</string>
+    <string name="control_enable">Aktivieren</string>
+    <string name="control_disable">Deaktivieren</string>
+</resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Διεύθυνση SOCKS:</string>
+    <string name="socks_udp_addr">Διεύθυνση UDP SOCKS:</string>
+    <string name="socks_port">Θύρα SOCKS:</string>
+    <string name="socks_user">Όνομα χρήστη SOCKS:</string>
+    <string name="socks_pass">Κωδικός SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP μέσω TCP</string>
+    <string name="remote_dns">Απομακρυσμένο DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Καθολικό</string>
+    <string name="apps">Εφαρμογές</string>
+    <string name="save">Αποθήκευση</string>
+    <string name="control_enable">Ενεργοποίηση</string>
+    <string name="control_disable">Απενεργοποίηση</string>
+</resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Dirección SOCKS:</string>
+    <string name="socks_udp_addr">Dirección UDP SOCKS:</string>
+    <string name="socks_port">Puerto SOCKS:</string>
+    <string name="socks_user">Usuario SOCKS:</string>
+    <string name="socks_pass">Contraseña SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP sobre TCP</string>
+    <string name="remote_dns">DNS remoto</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Aplicaciones</string>
+    <string name="save">Guardar</string>
+    <string name="control_enable">Activar</string>
+    <string name="control_disable">Desactivar</string>
+</resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-aadress:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-aadress:</string>
+    <string name="socks_port">SOCKS-port:</string>
+    <string name="socks_user">SOCKS-kasutajanimi:</string>
+    <string name="socks_pass">SOCKS-parool:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP üle TCP</string>
+    <string name="remote_dns">Kaug-DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globaalne</string>
+    <string name="apps">Rakendused</string>
+    <string name="save">Salvesta</string>
+    <string name="control_enable">Lülita sisse</string>
+    <string name="control_disable">Lülita välja</string>
+</resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-osoite:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-osoite:</string>
+    <string name="socks_port">SOCKS-portti:</string>
+    <string name="socks_user">SOCKS-käyttäjätunnus:</string>
+    <string name="socks_pass">SOCKS-salasana:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP TCP:n yli</string>
+    <string name="remote_dns">Etä-DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globaali</string>
+    <string name="apps">Sovellukset</string>
+    <string name="save">Tallenna</string>
+    <string name="control_enable">Ota käyttöön</string>
+    <string name="control_disable">Poista käytöstä</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Adresse SOCKS:</string>
+    <string name="socks_udp_addr">Adresse UDP SOCKS:</string>
+    <string name="socks_port">Port SOCKS:</string>
+    <string name="socks_user">Nom d'utilisateur SOCKS:</string>
+    <string name="socks_pass">Mot de passe SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP sur TCP</string>
+    <string name="remote_dns">DNS distant</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Applications</string>
+    <string name="save">Enregistrer</string>
+    <string name="control_enable">Activer</string>
+    <string name="control_disable">Désactiver</string>
+</resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Enderezo SOCKS:</string>
+    <string name="socks_udp_addr">Enderezo UDP SOCKS:</string>
+    <string name="socks_port">Porto SOCKS:</string>
+    <string name="socks_user">Usuario SOCKS:</string>
+    <string name="socks_pass">Contrasinal SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP sobre TCP</string>
+    <string name="remote_dns">DNS remoto</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Aplicacións</string>
+    <string name="save">Gardar</string>
+    <string name="control_enable">Activar</string>
+    <string name="control_disable">Desactivar</string>
+</resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS adresa:</string>
+    <string name="socks_udp_addr">SOCKS UDP adresa:</string>
+    <string name="socks_port">SOCKS port:</string>
+    <string name="socks_user">SOCKS korisničko ime:</string>
+    <string name="socks_pass">SOCKS lozinka:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP kroz TCP</string>
+    <string name="remote_dns">Udaljeni DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globalno</string>
+    <string name="apps">Aplikacije</string>
+    <string name="save">Spremi</string>
+    <string name="control_enable">Uključi</string>
+    <string name="control_disable">Isključi</string>
+</resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-cím:</string>
+    <string name="socks_udp_addr">SOCKS UDP-cím:</string>
+    <string name="socks_port">SOCKS-port:</string>
+    <string name="socks_user">SOCKS-felhasználónév:</string>
+    <string name="socks_pass">SOCKS-jelszó:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP TCP-n keresztül</string>
+    <string name="remote_dns">Távoli DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globális</string>
+    <string name="apps">Alkalmazások</string>
+    <string name="save">Mentés</string>
+    <string name="control_enable">Bekapcsolás</string>
+    <string name="control_disable">Kikapcsolás</string>
+</resources>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-vistfang:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-vistfang:</string>
+    <string name="socks_port">SOCKS-gátt:</string>
+    <string name="socks_user">SOCKS-notendanafn:</string>
+    <string name="socks_pass">SOCKS-lykilorð:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP yfir TCP</string>
+    <string name="remote_dns">Fjartengdur DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Alheims</string>
+    <string name="apps">Forrit</string>
+    <string name="save">Vista</string>
+    <string name="control_enable">Virka</string>
+    <string name="control_disable">Afvirkja</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Indirizzo SOCKS:</string>
+    <string name="socks_udp_addr">Indirizzo UDP SOCKS:</string>
+    <string name="socks_port">Porta SOCKS:</string>
+    <string name="socks_user">Nome utente SOCKS:</string>
+    <string name="socks_pass">Password SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP su TCP</string>
+    <string name="remote_dns">DNS remoto</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globale</string>
+    <string name="apps">App</string>
+    <string name="save">Salva</string>
+    <string name="control_enable">Attiva</string>
+    <string name="control_disable">Disattiva</string>
+</resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKSアドレス：</string>
+    <string name="socks_udp_addr">SOCKS UDPアドレス：</string>
+    <string name="socks_port">SOCKSポート：</string>
+    <string name="socks_user">SOCKSユーザー名：</string>
+    <string name="socks_pass">SOCKSパスワード：</string>
+    <string name="dns_ipv4">DNS IPv4：</string>
+    <string name="dns_ipv6">DNS IPv6：</string>
+    <string name="udp_in_tcp">UDP over TCP</string>
+    <string name="remote_dns">リモートDNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">グローバル</string>
+    <string name="apps">アプリ</string>
+    <string name="save">保存</string>
+    <string name="control_enable">有効</string>
+    <string name="control_disable">無効</string>
+</resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS 주소:</string>
+    <string name="socks_udp_addr">SOCKS UDP 주소:</string>
+    <string name="socks_port">SOCKS 포트:</string>
+    <string name="socks_user">SOCKS 사용자명:</string>
+    <string name="socks_pass">SOCKS 비밀번호:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">TCP를 통한 UDP</string>
+    <string name="remote_dns">원격 DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">전역</string>
+    <string name="apps">앱</string>
+    <string name="save">저장</string>
+    <string name="control_enable">활성화</string>
+    <string name="control_disable">비활성화</string>
+</resources>

--- a/app/src/main/res/values-ky/strings.xml
+++ b/app/src/main/res/values-ky/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS adresas:</string>
+    <string name="socks_udp_addr">SOCKS UDP adresas:</string>
+    <string name="socks_port">SOCKS prievadas:</string>
+    <string name="socks_user">SOCKS naudotojo vardas:</string>
+    <string name="socks_pass">SOCKS slaptažodis:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP per TCP</string>
+    <string name="remote_dns">Nuotolinis DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globalus</string>
+    <string name="apps">Programos</string>
+    <string name="save">Išsaugoti</string>
+    <string name="control_enable">Įjungti</string>
+    <string name="control_disable">Išjungti</string>
+</resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS adrese:</string>
+    <string name="socks_udp_addr">SOCKS UDP adrese:</string>
+    <string name="socks_port">SOCKS ports:</string>
+    <string name="socks_user">SOCKS lietotājvārds:</string>
+    <string name="socks_pass">SOCKS parole:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP caur TCP</string>
+    <string name="remote_dns">Attālais DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globāls</string>
+    <string name="apps">Lietotnes</string>
+    <string name="save">Saglabāt</string>
+    <string name="control_enable">Ieslēgt</string>
+    <string name="control_disable">Izslēgt</string>
+</resources>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS адреса:</string>
+    <string name="socks_udp_addr">SOCKS UDP адреса:</string>
+    <string name="socks_port">SOCKS порт:</string>
+    <string name="socks_user">SOCKS корисничко име:</string>
+    <string name="socks_pass">SOCKS лозинка:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP преку TCP</string>
+    <string name="remote_dns">Далечински DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Глобално</string>
+    <string name="apps">Апликации</string>
+    <string name="save">Зачувај</string>
+    <string name="control_enable">Вклучи</string>
+    <string name="control_disable">Исклучи</string>
+</resources>

--- a/app/src/main/res/values-mn/strings.xml
+++ b/app/src/main/res/values-mn/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-adresse:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-adresse:</string>
+    <string name="socks_port">SOCKS-port:</string>
+    <string name="socks_user">SOCKS-brukernavn:</string>
+    <string name="socks_pass">SOCKS-passord:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP over TCP</string>
+    <string name="remote_dns">Ekstern DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Apper</string>
+    <string name="save">Lagre</string>
+    <string name="control_enable">Aktiver</string>
+    <string name="control_disable">Deaktiver</string>
+</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-adres:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-adres:</string>
+    <string name="socks_port">SOCKS-poort:</string>
+    <string name="socks_user">SOCKS-gebruikersnaam:</string>
+    <string name="socks_pass">SOCKS-wachtwoord:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP via TCP</string>
+    <string name="remote_dns">Externe DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globaal</string>
+    <string name="apps">Apps</string>
+    <string name="save">Opslaan</string>
+    <string name="control_enable">Inschakelen</string>
+    <string name="control_disable">Uitschakelen</string>
+</resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Adres SOCKS:</string>
+    <string name="socks_udp_addr">Adres UDP SOCKS:</string>
+    <string name="socks_port">Port SOCKS:</string>
+    <string name="socks_user">Nazwa użytkownika SOCKS:</string>
+    <string name="socks_pass">Hasło SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP przez TCP</string>
+    <string name="remote_dns">Zdalny DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globalnie</string>
+    <string name="apps">Aplikacje</string>
+    <string name="save">Zapisz</string>
+    <string name="control_enable">Włącz</string>
+    <string name="control_disable">Wyłącz</string>
+</resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Endereço SOCKS:</string>
+    <string name="socks_udp_addr">Endereço UDP SOCKS:</string>
+    <string name="socks_port">Porta SOCKS:</string>
+    <string name="socks_user">Usuário SOCKS:</string>
+    <string name="socks_pass">Senha SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP sobre TCP</string>
+    <string name="remote_dns">DNS remoto</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Aplicativos</string>
+    <string name="save">Salvar</string>
+    <string name="control_enable">Ativar</string>
+    <string name="control_disable">Desativar</string>
+</resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Adresă SOCKS:</string>
+    <string name="socks_udp_addr">Adresă UDP SOCKS:</string>
+    <string name="socks_port">Port SOCKS:</string>
+    <string name="socks_user">Utilizator SOCKS:</string>
+    <string name="socks_pass">Parolă SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP prin TCP</string>
+    <string name="remote_dns">DNS la distanță</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Aplicații</string>
+    <string name="save">Salvează</string>
+    <string name="control_enable">Activează</string>
+    <string name="control_disable">Dezactivează</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Адрес SOCKS:</string>
+    <string name="socks_udp_addr">UDP-адрес SOCKS:</string>
+    <string name="socks_port">Порт SOCKS:</string>
+    <string name="socks_user">Имя пользователя SOCKS:</string>
+    <string name="socks_pass">Пароль SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP через TCP</string>
+    <string name="remote_dns">Удалённый DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Глобально</string>
+    <string name="apps">Приложения</string>
+    <string name="save">Сохранить</string>
+    <string name="control_enable">Включить</string>
+    <string name="control_disable">Выключить</string>
+</resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Adresa SOCKS:</string>
+    <string name="socks_udp_addr">UDP adresa SOCKS:</string>
+    <string name="socks_port">Port SOCKS:</string>
+    <string name="socks_user">Používateľské meno SOCKS:</string>
+    <string name="socks_pass">Heslo SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP cez TCP</string>
+    <string name="remote_dns">Vzdialený DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globálne</string>
+    <string name="apps">Aplikácie</string>
+    <string name="save">Uložiť</string>
+    <string name="control_enable">Zapnúť</string>
+    <string name="control_disable">Vypnúť</string>
+</resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS naslov:</string>
+    <string name="socks_udp_addr">SOCKS UDP naslov:</string>
+    <string name="socks_port">SOCKS vrata:</string>
+    <string name="socks_user">SOCKS uporabniško ime:</string>
+    <string name="socks_pass">SOCKS geslo:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP preko TCP</string>
+    <string name="remote_dns">Oddaljeni DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globalno</string>
+    <string name="apps">Aplikacije</string>
+    <string name="save">Shrani</string>
+    <string name="control_enable">Vključi</string>
+    <string name="control_disable">Izključi</string>
+</resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Adresa SOCKS:</string>
+    <string name="socks_udp_addr">Adresa UDP SOCKS:</string>
+    <string name="socks_port">Porta SOCKS:</string>
+    <string name="socks_user">Përdoruesi SOCKS:</string>
+    <string name="socks_pass">Fjalëkalimi SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP mbi TCP</string>
+    <string name="remote_dns">DNS në distancë</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Aplikacionet</string>
+    <string name="save">Ruaj</string>
+    <string name="control_enable">Aktivizo</string>
+    <string name="control_disable">Çaktivizo</string>
+</resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS adresa:</string>
+    <string name="socks_udp_addr">SOCKS UDP adresa:</string>
+    <string name="socks_port">SOCKS port:</string>
+    <string name="socks_user">SOCKS korisničko ime:</string>
+    <string name="socks_pass">SOCKS lozinka:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP preko TCP</string>
+    <string name="remote_dns">Udaljeni DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Globalno</string>
+    <string name="apps">Aplikacije</string>
+    <string name="save">Sačuvaj</string>
+    <string name="control_enable">Uključi</string>
+    <string name="control_disable">Isključi</string>
+</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">SOCKS-adress:</string>
+    <string name="socks_udp_addr">SOCKS-UDP-adress:</string>
+    <string name="socks_port">SOCKS-port:</string>
+    <string name="socks_user">SOCKS-användarnamn:</string>
+    <string name="socks_pass">SOCKS-lösenord:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP över TCP</string>
+    <string name="remote_dns">Fjärr-DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Global</string>
+    <string name="apps">Appar</string>
+    <string name="save">Spara</string>
+    <string name="control_enable">Aktivera</string>
+    <string name="control_disable">Inaktivera</string>
+</resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SocksTun</string>
+    <string name="socks_addr">Адреса SOCKS:</string>
+    <string name="socks_udp_addr">UDP-адреса SOCKS:</string>
+    <string name="socks_port">Порт SOCKS:</string>
+    <string name="socks_user">Ім\'я користувача SOCKS:</string>
+    <string name="socks_pass">Пароль SOCKS:</string>
+    <string name="dns_ipv4">DNS IPv4:</string>
+    <string name="dns_ipv6">DNS IPv6:</string>
+    <string name="udp_in_tcp">UDP через TCP</string>
+    <string name="remote_dns">Віддалений DNS</string>
+    <string name="ipv4">IPv4</string>
+    <string name="ipv6">IPv6</string>
+    <string name="global">Глобально</string>
+    <string name="apps">Додатки</string>
+    <string name="save">Зберегти</string>
+    <string name="control_enable">Увімкнути</string>
+    <string name="control_disable">Вимкнути</string>
+</resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="app_name">SocksTun</string>
+	<string name="socks_addr">Socks Address:</string>
+	<string name="socks_udp_addr">Socks UDP Address:</string>
+	<string name="socks_port">Socks Port:</string>
+	<string name="socks_user">Socks Username:</string>
+	<string name="socks_pass">Socks Password:</string>
+	<string name="dns_ipv4">DNS IPv4:</string>
+	<string name="dns_ipv6">DNS IPv6:</string>
+	<string name="udp_in_tcp">UDP relay over TCP</string>
+	<string name="remote_dns">Remote DNS</string>
+	<string name="ipv4">IPv4</string>
+	<string name="ipv6">IPv6</string>
+	<string name="global">Global</string>
+	<string name="apps">Apps</string>
+	<string name="save">Save</string>
+	<string name="control_enable">Enable</string>
+	<string name="control_disable">Disable</string>
+</resources>


### PR DESCRIPTION
- Add strings.xml translations for 59 languages
- Supported languages: AF, AM, AR, AS, AZ, BE, BG, BS, CA, CS, DA, DE, EL, EN, ES, ET, EU, FA, FI, FR, GL, HR, HU, HY, IN, IS, IT, IW, JA, KA, KK, KM, KO, KY, LO, LT, LV, MK, MN, MS, NB, NL, PL, PT, RO, RU, SI, SK, SL, SQ, SR, SV, SW, TH, TL, TR, UK, UZ, VI, ZU